### PR TITLE
Add duration to VzaarApi::Video

### DIFF
--- a/lib/vzaar_api/video.rb
+++ b/lib/vzaar_api/video.rb
@@ -4,7 +4,7 @@ module VzaarApi
 
     ATTR_READERS = [:id, :user_id, :account_id, :categories,
                     :renditions, :legacy_renditions, :url,
-                    :thumbnail_url, :state,
+                    :thumbnail_url, :state, :duration,
                     :created_at, :updated_at].freeze
 
     ATTR_ACCESSORS = [:category_ids, :description, :private, :seo_url, :title].freeze

--- a/spec/vzaar_api/video_spec.rb
+++ b/spec/vzaar_api/video_spec.rb
@@ -20,6 +20,7 @@ module VzaarApi
           url: 'url',
           thumbnail_url: 'thumbnail_url',
           state: 'state',
+          duration: 'duration',
           categories: categories,
           renditions: renditions,
           created_at: 'created_at',
@@ -45,6 +46,7 @@ module VzaarApi
       specify { expect(subject.url).to eq 'url' }
       specify { expect(subject.thumbnail_url).to eq 'thumbnail_url' }
       specify { expect(subject.state).to eq 'state' }
+      specify { expect(subject.duration).to eq 'duration' }
       specify { expect(subject.categories.first.id).to eq 'category-id' }
       specify { expect(subject.renditions.first.id).to eq 'rendition-id' }
       specify { expect(subject.created_at).to eq 'created_at' }
@@ -101,6 +103,7 @@ module VzaarApi
             expect(video.url).to eq 'video-url'
             expect(video.thumbnail_url).to eq 'https://view.vzaar.localhost/7574982/thumb'
             expect(video.state).to eq 'ready'
+            expect(video.duration).to eq 66.7
             expect(video.categories.count).to eq 2
             expect(video.renditions.count).to eq 8
             expect(video.legacy_renditions.count).to eq 8


### PR DESCRIPTION
When looking up a video, Vzaar's API response JSON includes the duration
of a video, among other metadata.

Currently this is not exposed in VzaarApi::Video. This commit adds a
read-only `.duration` attribute to VzaarApi::Video.